### PR TITLE
Windows patches

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -27,5 +27,7 @@ setup
 
 for CONFERB in $(find src -name *.conf.erb) ; do
     echo "compiling ${CONFERB}..."
-    $RUBYCMD -e "require 'erb'; puts ERB.new(File.read('$CONFERB')).result(binding)" > target/`basename "$CONFERB" | rev | cut -c5- | rev`
+	target_file=`basename $CONFERB`
+	target_file=${target_file%.erb}
+    $RUBYCMD -e "require 'erb'; puts ERB.new(File.read('$CONFERB')).result(binding)" > target/$target_file
 done

--- a/bin/install_deps.sh
+++ b/bin/install_deps.sh
@@ -19,8 +19,23 @@ fi
 
 if [ ! -e vendor/logstash ] ; then
   mkdir vendor/logstash
-  wget -qO- "https://github.com/elasticsearch/logstash/archive/v$LOGSTASH_VERSION.tar.gz" | tar -xzf- -C vendor/logstash --strip-components 1
+  curl -L "https://github.com/elasticsearch/logstash/archive/v$LOGSTASH_VERSION.tar.gz" | tar -xzf- -C vendor/logstash --strip-components 1
 fi
+
+if [ "$OS" == "Windows_NT" ] ; then
+	echo "Setting up extra Windows dependencies"
+	if ! which make ; then
+	  pushd $TMP
+	  curl -L -O http://gnuwin32.sourceforge.net/downlinks/make-bin-zip.php
+	  unzip make-bin-zip.php -d / bin/make.exe
+	  curl -L -O http://gnuwin32.sourceforge.net/downlinks/make-dep-zip.php
+	  unzip make-dep-zip.php -d / bin/libiconv2.dll bin/libintl3.dll
+	  
+	  rm -f make-bin-zip.php 
+	  rm -f make-dep-zip.php
+	  popd
+	fi
+fi 
 
 cd vendor/logstash
 


### PR DESCRIPTION
Minor changes to ensure these scripts can be run on under the SourceTree terminal app on Windows where:
- `rev` isn't available (uses `${CONFERB%.erb}` instead)
- `wget` isn't available (uses `curl` instead)
- `make` isn't available (installs `gnuwin32 :: make`)
