### PR TITLE
Check the correct grok failure tag, workaround for logstash bug #1849 

### DIFF
--- a/src/10-syslog_standard.conf
+++ b/src/10-syslog_standard.conf
@@ -12,18 +12,21 @@ if [@type] in ["syslog", "relp"] {
             match => [ "syslog_timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss", "ISO8601" ]
         }
 
+        # hostname: handle syslog configurations where hostname is localhost
         if ([syslog_hostname] == "localhost" ) {
-            mutate {
-                replace => [ "@source.host", "%{host}" ]
-            }
-        } else {
-            mutate {
-                replace => [ "@source.host", "%{syslog_hostname}" ]
+            grok {
+                match => { "received_from" => "%{IPORHOST:syslog_hostname}(?::%{POSINT:syslog_port})?" }
+                overwrite => [ "syslog_hostname", "syslog_port" ]
+                tag_on_failure => [ "_grokparsefailure-syslog_standard-hostname"]
             }
         }
 
         mutate {
-            remove_field => [ "syslog_pri", "syslog_hostname", "syslog_timestamp" ]
+            replace => [ "@source.host", "%{syslog_hostname}" ]
+        }
+
+        mutate {
+            remove_field => [ "syslog_pri", "syslog_hostname", "syslog_port", "syslog_timestamp" ]
         }
     }
 }

--- a/test/syslog_standard-spec.rb
+++ b/test/syslog_standard-spec.rb
@@ -11,7 +11,7 @@ describe LogStash::Filters::Grok do
   CONFIG
 
   describe "Accepting standard syslog message without PID specified" do
-    sample("@type" => "syslog", "host" => "1.2.3.4", "@message" => '<85>Apr 24 02:05:03 localhost sudo: bosh_h5156e598 : TTY=pts/0 ; PWD=/var/vcap/bosh_ssh/bosh_h5156e598 ; USER=root ; COMMAND=/bin/pwd') do
+    sample("@type" => "syslog", "host" => "1.2.3.4:12345", "@message" => '<85>Apr 24 02:05:03 localhost sudo: bosh_h5156e598 : TTY=pts/0 ; PWD=/var/vcap/bosh_ssh/bosh_h5156e598 ; USER=root ; COMMAND=/bin/pwd') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
       insist { subject["@type"] } == 'syslog'
       insist { subject["@timestamp"] } == Time.iso8601("2014-04-23T14:05:03.000Z").utc


### PR DESCRIPTION
Turns out I missed checking the correct tag name on the filter.  Not sure how we can test for that, as the only thing that would be present would be the failure tag (which we're already testing for).

Also capture the hostname correctly, as tcp/udp inputs currently include ip:port (rather than just IP) - [Logstash bug #1849](https://logstash.jira.com/browse/LOGSTASH-1849)
