### PR TITLE
Ensure timezone consistency

### DIFF
--- a/src/10-syslog_standard.conf
+++ b/src/10-syslog_standard.conf
@@ -10,6 +10,7 @@ if [@type] in ["syslog", "relp"] {
         syslog_pri { }
         date {
             match => [ "syslog_timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss", "ISO8601" ]
+            timezone => "UTC"
         }
 
         if ([syslog_hostname] == "localhost" ) {

--- a/src/75-elasticsearch_request.conf
+++ b/src/75-elasticsearch_request.conf
@@ -9,5 +9,6 @@ if [@type] == "elasticsearch_request" {
 
   date {
     match => [ "starttime", "ISO8601" ]
+    timezone => "UTC"
   }
 }

--- a/src/75-nginx_combined.conf
+++ b/src/75-nginx_combined.conf
@@ -7,5 +7,6 @@ if [@type] == "nginx_combined" {
 
   date {
     match => [ "time_local", "dd/MMM/YYYY:HH:mm:ss Z" ]
+    timezone => "UTC"
   }
 }

--- a/test/nginx_combined-spec.rb
+++ b/test/nginx_combined-spec.rb
@@ -16,7 +16,7 @@ describe LogStash::Filters::Grok do
 
       insist { subject["@type"] } == "nginx_combined"
       insist { subject["tags"] } == [ 'nginx' ]
-      insist { subject["@timestamp"] } == Time.iso8601("2013-06-06T07:28:33.000Z").utc
+      insist { subject["@timestamp"] } == Time.iso8601("2013-06-06T07:28:33.000Z")
 
       insist { subject['remote_addr'] } == '192.0.2.15'
       insist { subject['remote_user'] } == '-'

--- a/test/syslog_standard-spec.rb
+++ b/test/syslog_standard-spec.rb
@@ -11,10 +11,10 @@ describe LogStash::Filters::Grok do
   CONFIG
 
   describe "Accepting standard syslog message without PID specified" do
-    sample("@type" => "syslog", "host" => "1.2.3.4", "@message" => '<85>Apr 24 02:05:03 localhost sudo: bosh_h5156e598 : TTY=pts/0 ; PWD=/var/vcap/bosh_ssh/bosh_h5156e598 ; USER=root ; COMMAND=/bin/pwd') do
+    sample("@type" => "syslog", "host" => "1.2.3.4", "@message" => '<85>Apr 24 14:05:03 localhost sudo: bosh_h5156e598 : TTY=pts/0 ; PWD=/var/vcap/bosh_ssh/bosh_h5156e598 ; USER=root ; COMMAND=/bin/pwd') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
       insist { subject["@type"] } == 'syslog'
-      insist { subject["@timestamp"] } == Time.iso8601("2014-04-23T14:05:03.000Z").utc
+      insist { subject["@timestamp"] } == Time.iso8601("2014-04-24T14:05:03.000Z")
       insist { subject['@source.host'] } == '1.2.3.4'
 
       insist { subject['syslog_facility'] } == 'security/authorization'
@@ -31,7 +31,7 @@ describe LogStash::Filters::Grok do
     sample("@type" => "relp", "host" => "1.2.3.4", "@message" => '<78>Apr 24 04:03:06 localhost crontab[32185]: (root) LIST (root)') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
       insist { subject["@type"] } == 'relp'
-      insist { subject["@timestamp"] } == Time.iso8601("2014-04-23T16:03:06.000Z").utc
+      insist { subject["@timestamp"] } == Time.iso8601("2014-04-24T04:03:06.000Z")
       insist { subject['@source.host'] } == '1.2.3.4'
 
       insist { subject['syslog_facility'] } == 'clock'
@@ -48,7 +48,7 @@ describe LogStash::Filters::Grok do
     sample("@type" => "syslog", "host" => "1.2.3.4", "@message" => '<14>2014-04-23T23:19:01.227366+00:00 172.31.201.31 vcap.nats [job=vcap.nats index=1]  {\"timestamp\":1398295141.227022}') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
       insist { subject["@type"] } == 'syslog'
-      insist { subject["@timestamp"] } == Time.iso8601("2014-04-23T23:19:01.227Z").utc
+      insist { subject["@timestamp"] } == Time.iso8601("2014-04-23T23:19:01.227Z")
       insist { subject['@source.host'] } == '172.31.201.31'
 
       insist { subject['syslog_facility'] } == 'user-level'


### PR DESCRIPTION
This ensures `date` filters have a default timezone applied in case the time value does not explicitly specify one. This is something we've done on our internal filters, but is missing in this repo.

It feels a bit odd to do this, because, in some cases, users may be _required_ to adjust the time (e.g. `syslog`) since the protocol may not include it and the users are not actually within UTC. However, I think they can/should deal with that in a later, user-specific filter which adjusts the time by `x` number of hours. I think it's more important for our tests to pass consistently across all time zones.
