### PR TITLE
Switch structured-data handling to main syslog snippet

### DIFF
--- a/src/logstash/defaults.conf.erb
+++ b/src/logstash/defaults.conf.erb
@@ -1,8 +1,5 @@
 if [@type] in ["syslog", "relp"] {
 <%= File.read('src/logstash/snippets/syslog_standard.conf').gsub(/^/, '  ') %>
-}
-
-if [@type] == "syslog" and [syslog_message] =~ /^\- \- \[NXLOG/ {
 <%= File.read('src/logstash/snippets/nxlog_standard.conf').gsub(/^/m, '  ') %>
 }
 

--- a/src/logstash/snippets/nxlog_standard.conf
+++ b/src/logstash/snippets/nxlog_standard.conf
@@ -36,8 +36,5 @@ if "NXLOG@14506" == [syslog_sd_id] {
         rename => [ "@source[EventReceivedTime]", "@shipper[event_received_time]" ]
         rename => [ "@source[SourceModuleName]", "@shipper[module_name]" ]
         rename => [ "@source[SourceModuleType]", "@shipper[module_type]" ]
-
-        # @source[type] should replace the syslog @type
-        rename => [ "@source[type]", "@type" ]
     }
 }

--- a/src/logstash/snippets/nxlog_standard.conf
+++ b/src/logstash/snippets/nxlog_standard.conf
@@ -1,20 +1,19 @@
-grok {
-    match => [ "syslog_message", "\- \- \[NXLOG@14506 (?<shipper[source_params]>[^\]]+)\] %{GREEDYDATA:@message}" ]
-    overwrite => [
-        "@message"
-    ]
-    tag_on_failure => [ "_grokparsefailure-nxlog_standard" ]
-}
+if "NXLOG@14506" == [syslog_sd_id] {
+    # We're going to treat syslog as a transparent transport and pretend it was never even
+    # utilized. This means we'll drop the syslog metadata, but it really shouldn't matter.
 
-if "_grokparsefailure-nxlog_standard" not in [tags] {
-    # grok doesn't like @named groups
     mutate {
-        rename => [ "shipper", "@shipper" ]
+        # This is a workaround to an apparent bug where logstash treats a non-existant field
+        # as an array which causes a "Not possible to merge an array and a hash" error. Here
+        # we force the probably non-existant field to a hash with a temp field so we can use
+        # the mutate's merge option.
+        add_field => [ "@source[_forcemeahash]", "workaround" ]
     }
 
-    kv {
-      source => "@shipper[source_params]"
-      target => "@source"
+    mutate {
+        merge => [ "@source", "syslog_sd_params" ]
+        rename => [ "syslog_message", "@message" ]
+        remove_field => [ "@source[_forcemeahash]" ]
     }
 
     mutate {
@@ -27,12 +26,11 @@ if "_grokparsefailure-nxlog_standard" not in [tags] {
         remove_field => "syslog_facility_code"
         remove_field => "syslog_facility"
         remove_field => "syslog_severity"
+        remove_field => "syslog_sd_id"
+        remove_field => "syslog_sd_params"
 
         # syslog host is actually the shipper
         rename => [ "@source.host", "@shipper[host]" ]
-
-        # these arbitrary parameters are parsed to @source
-        remove_field => "@shipper[source_params]"
 
         # these are parsed with kv, but they're static nxlog shipper properties
         rename => [ "@source[EventReceivedTime]", "@shipper[event_received_time]" ]

--- a/src/logstash/snippets/syslog_standard.conf
+++ b/src/logstash/snippets/syslog_standard.conf
@@ -39,4 +39,38 @@ if !("_grokparsefailure-syslog_standard" in [tags]) {
             "syslog_timestamp"
         ]
     }
+
+    if [syslog5424_ver] == 1 {
+        grok {
+            # I don't think this is rfc5424-legal because it says SD *must* exist and message *may* exist.
+            # However, this makes parsing compatible with common syslog implementations.
+            match => [ "syslog_message", "(?:%{DATA:syslog_procid}|\-) (?:%{DATA:syslog_msgid}|\-)(?: %{SYSLOG5424SD:syslog_sd}| \-)? %{GREEDYDATA:syslog_message}" ]
+            overwrite => [
+                "syslog_message"
+            ]
+            tag_on_failure => [ "_grokparsefailure-syslog_standard-5424" ]
+        }
+
+        # structured-data
+        if [syslog_sd] {
+            grok {
+                match => [ "syslog_sd", "\[%{DATA:syslog_sd_id} (?<syslog_sd_params_raw]>[^\]]+)\]" ]
+                remove_field => [
+                    "syslog_sd"
+                ]
+                tag_on_failure => [ "_grokparsefailure-syslog_standard-5424/sds" ]
+            }
+
+            if !("_grokparsefailure-syslog_standard-5424/sd" in [tags]) {
+                # convert the the key-value pairs
+                kv {
+                    source => "syslog_sd_params_raw"
+                    target => "syslog_sd_params"
+                    remove_field => [
+                        "syslog_sd_params_raw"
+                    ]
+                }
+            }
+        }
+    }
 }

--- a/src/logstash/snippets/syslog_standard.conf
+++ b/src/logstash/snippets/syslog_standard.conf
@@ -70,6 +70,14 @@ if !("_grokparsefailure-syslog_standard" in [tags]) {
                         "syslog_sd_params_raw"
                     ]
                 }
+
+                if [syslog_sd_params][type] {
+                    # establish a convention that a structured data key of "type" will be the log type
+                    mutate {
+                        replace => { "@type" => "%{syslog_sd_params[type]}" }
+                        remove_field => [ "syslog_sd_params[type]" ]
+                    }
+                }
             }
         }
     }

--- a/test/logstash/snippets/syslog_standard-spec.rb
+++ b/test/logstash/snippets/syslog_standard-spec.rb
@@ -78,7 +78,9 @@ describe LogStash::Filters::Grok do
       insist { subject['syslog_facility_code'] } === 1
       insist { subject['syslog_facility'] } === 'user-level'
 
-      insist { subject['syslog_message'] } == '[App/0] - - {"@timestamp":"2014-05-20T20:40:49.907Z","message":"LowRequestRate 2014-05-20T15:44:58.794Z","@source.name":"watcher-bot-ppe","logger":"logsearch_watcher_bot.Program","level":"WARN"}'
+      insist { subject['syslog_procid'] } == '[App/0]'
+      insist { subject['syslog_msgid'] } == '-'
+      insist { subject['syslog_message'] } == '{"@timestamp":"2014-05-20T20:40:49.907Z","message":"LowRequestRate 2014-05-20T15:44:58.794Z","@source.name":"watcher-bot-ppe","logger":"logsearch_watcher_bot.Program","level":"WARN"}'
 
       insist { subject['received_at'] }.class == Time
       insist { subject['received_from'] } == 'rspec'
@@ -97,7 +99,9 @@ describe LogStash::Filters::Grok do
       insist { subject['syslog_facility_code'] } === 1
       insist { subject['syslog_facility'] } === 'user-level'
 
-      insist { subject['syslog_message'] } == '[App/0] - - Updating AppSettings for /home/vcap/app/logsearch-watcher-bot.exe.config'
+      insist { subject['syslog_procid'] } == '[App/0]'
+      insist { subject['syslog_msgid'] } == '-'
+      insist { subject['syslog_message'] } == 'Updating AppSettings for /home/vcap/app/logsearch-watcher-bot.exe.config'
 
       insist { subject['received_at'] }.class == Time
       insist { subject['received_from'] } == 'rspec'
@@ -116,7 +120,9 @@ describe LogStash::Filters::Grok do
       insist { subject['syslog_facility_code'] } === 1
       insist { subject['syslog_facility'] } === 'user-level'
 
-      insist { subject['syslog_message'] } == '[App/0] - -'
+      insist { subject['syslog_procid'] } == '[App/0]'
+      insist { subject['syslog_msgid'] } == '-'
+      insist { subject['syslog_message'] } == '-'
 
       insist { subject['received_at'] }.class == Time
       insist { subject['received_from'] } == 'rspec'

--- a/test/logstash/snippets/syslog_standard-spec.rb
+++ b/test/logstash/snippets/syslog_standard-spec.rb
@@ -13,7 +13,7 @@ describe LogStash::Filters::Grok do
   describe "Accepting standard syslog message without PID specified" do
     sample("host" => "1.2.3.4:12345", "@message" => '<85>Apr 24 02:05:03 localhost sudo: bosh_h5156e598 : TTY=pts/0 ; PWD=/var/vcap/bosh_ssh/bosh_h5156e598 ; USER=root ; COMMAND=/bin/pwd') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
-      insist { subject["@timestamp"] } == Time.iso8601("2014-04-24T02:05:03.000Z")
+      insist { subject["@timestamp"] } == Time.iso8601("#{Time.now.year}-04-24T02:05:03.000Z")
       insist { subject['@source.host'] } == '1.2.3.4'
 
       insist { subject['syslog_facility'] } == 'security/authorization'
@@ -29,7 +29,7 @@ describe LogStash::Filters::Grok do
   describe "Accepting standard syslog message with PID specified" do
     sample("host" => "1.2.3.4", "@message" => '<78>Apr 24 04:03:06 localhost crontab[32185]: (root) LIST (root)') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
-      insist { subject["@timestamp"] } == Time.iso8601("2014-04-24T04:03:06.000Z")
+      insist { subject["@timestamp"] } == Time.iso8601("#{Time.now.year}-04-24T04:03:06.000Z")
       insist { subject['@source.host'] } == '1.2.3.4'
 
       insist { subject['syslog_facility'] } == 'clock'


### PR DESCRIPTION
This adds structured-data parsing to the main syslog snippet. It's basically a refactoring of what was already in nxlog, just on a more general level. I don't have any additional commits planned for this - I'd just like to wait on merging until this gets tested more on our meta cluster with a wider range of data.