### PR TITLE
When running in the logsearch-workspace, use the system logstash

### DIFF
--- a/bin/install_deps.sh
+++ b/bin/install_deps.sh
@@ -18,10 +18,10 @@ else
 fi
 
 # The logsearch-workspace already contains logstash, so use that
-if [ -e /var/local/logstash-$LOGSTASH_VERSION ] ; then
-  echo "Detected that running in Logsearch Workspace.  Linking to logstash at /var/local/logstash-$LOGSTASH_VERSION" 
+if [ -e /usr/local/logstash-$LOGSTASH_VERSION ] ; then
+  echo "Detected that running in Logsearch Workspace.  Linking to logstash at /usr/local/logstash-$LOGSTASH_VERSION" 
   if [ ! -e vendor/logstash ] ; then
-     ln -s /var/local/logstash-$LOGSTASH_VERSION vendor/logstash
+     ln -s /usr/local/logstash-$LOGSTASH_VERSION vendor/logstash
   fi
   exit
 fi

--- a/bin/install_deps.sh
+++ b/bin/install_deps.sh
@@ -17,6 +17,15 @@ else
   LOGSTASH_VERSION=$1
 fi
 
+# The logsearch-workspace already contains logstash, so use that
+if [ -e /var/local/logstash-$LOGSTASH_VERSION ] ; then
+  echo "Detected that running in Logsearch Workspace.  Linking to logstash at /var/local/logstash-$LOGSTASH_VERSION" 
+  if [ ! -e vendor/logstash ] ; then
+     ln -s /var/local/logstash-$LOGSTASH_VERSION vendor/logstash
+  fi
+  exit
+fi
+
 if [ ! -e vendor/logstash ] ; then
   mkdir vendor/logstash
   curl -L "https://github.com/elasticsearch/logstash/archive/v$LOGSTASH_VERSION.tar.gz" | tar -xzf- -C vendor/logstash --strip-components 1


### PR DESCRIPTION
The PR patches `bin/install_deps.sh` to use the bundled system logstash when running in the context of the logsearch-workspace.

This speeds up using `logsearch-filter-*` in when working in the workspace AND enables [![logsearch/workspace/pull/5](https://github-shields.cfapps.io/github/logsearch/workspace/pull/5.svg)](https://github-shields.cfapps.io/github/logsearch/workspace/pull/5) (see [comment](https://github.com/logsearch/workspace/pull/5#issuecomment-69961009) )
It does nothing in other contexts.
